### PR TITLE
fix(gh-pages): 在构建目录中添加404.html文件

### DIFF
--- a/shells/gh-pages.sh
+++ b/shells/gh-pages.sh
@@ -12,6 +12,7 @@ npm run build
 
 # 进入构建目录
 cd dist
+cp index.html 404.html
 
 # 初始化 git 仓库（如果不存在）
 if [ ! -d .git ]; then


### PR DESCRIPTION
确保在GitHub Pages部署时能正确处理路由回退